### PR TITLE
darwin: fix display name not showing during scan

### DIFF
--- a/quick_blue_darwin/darwin/Classes/QuickBlueDarwinPlugin.swift
+++ b/quick_blue_darwin/darwin/Classes/QuickBlueDarwinPlugin.swift
@@ -353,11 +353,15 @@ extension QuickBlueDarwinPlugin: CBCentralManagerDelegate {
             let serviceUuids =
                 advertisementData[CBAdvertisementDataServiceUUIDsKey] as? [CBUUID]
                 ?? []
+            // Prioritize advertised local name over peripheral.name
+            // peripheral.name can be nil or stale, but CBAdvertisementDataLocalNameKey contains the current advertised name
+            let localName = advertisementData[CBAdvertisementDataLocalNameKey] as? String
+            let deviceName = localName ?? peripheral.name ?? ""
             if targetManufacturerData != nil {
                 if targetManufacturerData == manufacturerData {
                     scanResultListener.onEvent(
                         event: PlatformScanResult(
-                            name: peripheral.name ?? "",
+                            name: deviceName,
                             deviceId: peripheral.identifier.uuidString,
                             manufacturerDataHead: FlutterStandardTypedData(
                                 bytes: manufacturerData ?? Data()
@@ -373,7 +377,7 @@ extension QuickBlueDarwinPlugin: CBCentralManagerDelegate {
             } else {
                 scanResultListener.onEvent(
                     event: PlatformScanResult(
-                        name: peripheral.name ?? "",
+                        name: deviceName,
                         deviceId: peripheral.identifier.uuidString,
                         manufacturerDataHead: FlutterStandardTypedData(
                             bytes: Data()


### PR DESCRIPTION
When scanning for BLE devices, peripheral.name can sometimes be nil or stale. The advertised local name from CBAdvertisementDataLocalNameKey is more reliable and contains the current advertised name from the device.

This should fix the issue where some devices would only show their UUID instead of their display name during scanning.

https://pisontechnology.atlassian.net/browse/PA-501